### PR TITLE
Fixed bug where BuildDestinationUri was dropping a '/'.

### DIFF
--- a/src/ApiProxyTests/Core/ApiTransactionUtilityTests.cs
+++ b/src/ApiProxyTests/Core/ApiTransactionUtilityTests.cs
@@ -24,7 +24,7 @@ namespace EdFiValidation.ApiProxyTests.Core
             var actual = pathInspector.DecodeDestination(EncodedUrl);
             
             // assert
-            Assert.IsTrue(expected == actual);
+            Assert.IsTrue(expected.ToString() == actual);
         }
         
 

--- a/src/Core/Utility/ApiTransactionUtility.cs
+++ b/src/Core/Utility/ApiTransactionUtility.cs
@@ -114,23 +114,16 @@ namespace EdFiValidation.ApiProxy.Core.Utility
         public Uri BuildDestinationUri(Uri uri)
         {
             // the 2 represents the segment used for intent (sessionId for example)
-            var path = uri.Segments.Skip(4).Aggregate((m, n) => m.Replace("/", "") + "/" + n);
+            var destinationPath = uri.Segments.Skip(4).Aggregate((m, n) => m + n);  //was ((m, n) => m.Replace("/", "") + "/" + n). This was dropping the '/' btwn clientId and destination action.   Not sure what the intent was here
+            // foo.com/api/{sessionId}/{EncodedDestination}/{clientId}/{DistionationAction?}/{id}  becomes   {clientId}/{DistionationAction?}/{id}
 
-      
             // decode url, should be second item in array
             var rootDestination = ExtractDestination(uri);
 
-            if (!rootDestination.EndsWith("/"))
-                rootDestination += "/";
-
-            var dest = new Uri(rootDestination + path);
-            
-            var uriBuilder = new UriBuilder
-            {
-                Scheme = dest.Scheme, 
-                Host = dest.Host,
-                Path = dest.AbsolutePath
-            };
+            var uriBuilder = new UriBuilder(rootDestination)
+                {
+                    Path = destinationPath
+                };
 
             if (!string.IsNullOrWhiteSpace(uri.Query))
                 uriBuilder.Query = uri.Query.Replace("?", "");


### PR DESCRIPTION
Cleaned up the uriBuilder in the same function.
